### PR TITLE
[Java & Python] Include PDB Files in Debug Builds for Compressed Language Extensions

### DIFF
--- a/language-extensions/java/build/windows/create-java-extension-zip.cmd
+++ b/language-extensions/java/build/windows/create-java-extension-zip.cmd
@@ -20,11 +20,12 @@ SET OUTPUT_JAR="%ENL_ROOT%\build-output\java-extension\target\%BUILD_CONFIGURATI
 
 mkdir %BUILD_OUTPUT%\packages
 
+REM Set common files to be included in the zip
+SET INCLUDE_FILES=%BUILD_OUTPUT%\javaextension.dll, %OUTPUT_JAR%
+
 REM Check if BUILD_CONFIGURATION is debug, then include javaextension.pdb in the zip
 IF /I "%BUILD_CONFIGURATION%"=="debug" (
-    SET INCLUDE_FILES=%BUILD_OUTPUT%\javaextension.dll, %OUTPUT_JAR%, %BUILD_OUTPUT%\javaextension.pdb
-) ELSE (
-    SET INCLUDE_FILES=%BUILD_OUTPUT%\javaextension.dll, %OUTPUT_JAR%
+    SET INCLUDE_FILES=%INCLUDE_FILES%, %BUILD_OUTPUT%\javaextension.pdb
 )
 
 powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Compress-Archive -Path %INCLUDE_FILES% -DestinationPath %BUILD_OUTPUT%\packages\java-lang-extension.zip -Force"

--- a/language-extensions/java/build/windows/create-java-extension-zip.cmd
+++ b/language-extensions/java/build/windows/create-java-extension-zip.cmd
@@ -19,7 +19,15 @@ SET BUILD_OUTPUT=%ENL_ROOT%\build-output\java-extension\windows\%BUILD_CONFIGURA
 SET OUTPUT_JAR="%ENL_ROOT%\build-output\java-extension\target\%BUILD_CONFIGURATION%\mssql-java-lang-extension.jar"
 
 mkdir %BUILD_OUTPUT%\packages
-powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Compress-Archive -Path %BUILD_OUTPUT%\javaextension.dll, %OUTPUT_JAR% -DestinationPath %BUILD_OUTPUT%\packages\java-lang-extension.zip -Force"
+
+REM Check if BUILD_CONFIGURATION is debug, then include javaextension.pdb in the zip
+IF /I "%BUILD_CONFIGURATION%"=="debug" (
+    SET INCLUDE_FILES=%BUILD_OUTPUT%\javaextension.dll, %OUTPUT_JAR%, %BUILD_OUTPUT%\javaextension.pdb
+) ELSE (
+    SET INCLUDE_FILES=%BUILD_OUTPUT%\javaextension.dll, %OUTPUT_JAR%
+)
+
+powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Compress-Archive -Path %INCLUDE_FILES% -DestinationPath %BUILD_OUTPUT%\packages\java-lang-extension.zip -Force"
 CALL :CHECK_BUILD_ERROR %ERRORLEVEL% %BUILD_CONFIGURATION%
 
 REM Advance arg passed to create-java-extension.cmd
@@ -33,9 +41,9 @@ IF NOT "%~1"=="" GOTO LOOP
 EXIT /b %ERRORLEVEL%
 
 :CHECK_BUILD_ERROR
-	IF %1 == 0 (
-		ECHO Success: Created zip for %2 config
-	) ELSE (
-		ECHO Error: Failed to create zip for %2 config
-		EXIT /b %1
-	)
+    IF %1 == 0 (
+        ECHO Success: Created zip for %2 config
+    ) ELSE (
+        ECHO Error: Failed to create zip for %2 config
+        EXIT /b %1
+    )

--- a/language-extensions/python/build/windows/create-python-extension-zip.cmd
+++ b/language-extensions/python/build/windows/create-python-extension-zip.cmd
@@ -19,7 +19,14 @@ SET BUILD_OUTPUT=%ENL_ROOT%\build-output\pythonextension\windows\%BUILD_CONFIGUR
 
 mkdir %BUILD_OUTPUT%\packages
 
-powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Compress-Archive -Path %BUILD_OUTPUT%\pythonextension.dll -DestinationPath %BUILD_OUTPUT%\packages\python-lang-extension.zip -Force"
+REM Check if BUILD_CONFIGURATION is debug, then include pythonextension.pdb in the zip
+IF /I "%BUILD_CONFIGURATION%"=="debug" (
+    SET INCLUDE_FILES=%BUILD_OUTPUT%\pythonextension.dll, %BUILD_OUTPUT%\pythonextension.pdb
+) ELSE (
+    SET INCLUDE_FILES=%BUILD_OUTPUT%\pythonextension.dll
+)
+
+powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Compress-Archive -Path %INCLUDE_FILES% -DestinationPath %BUILD_OUTPUT%\packages\python-lang-extension.zip -Force"
 
 CALL :CHECK_BUILD_ERROR %ERRORLEVEL% %BUILD_CONFIGURATION%
 


### PR DESCRIPTION
This PR updates the build scripts for Java and Python language extensions to enhance debugging support. Specifically, it introduces a new feature for debug build environments:

- **For Java and Python extensions:** When building in a debug environment, `.pdb` files will now be included along with `.dll` files in the generated zip packages. This addition is crucial for providing necessary debug symbols, facilitating a smoother debugging experience.

**Key Points:**
- **C# Extensions:** Already include `.pdb` files by default, so no changes here.
- **R Extensions:** The cv2pdb package was previously employed to generate `.pdb` files for R extensions but has been removed due to its deprecation and the lack of a secure lineage, aligning with secure supply chain requirements. Therefore no changes here.

**Background:**
The decision to include `.pdb` files for Java and Python extensions in debug builds aims to improve the development process by ensuring developers have access to essential debugging symbols. This move aligns with our goals to enhance security and efficiency in our development practices.
