### PR TITLE
[Csharp Extension] Removal of PDB Files from C# Extension Release Build

### DIFF
--- a/language-extensions/dotnet-core-CSharp/build/windows/create-dotnet-core-CSharp-extension-zip.cmd
+++ b/language-extensions/dotnet-core-CSharp/build/windows/create-dotnet-core-CSharp-extension-zip.cmd
@@ -21,16 +21,20 @@ SET BUILD_OUTPUT=%DOTNET_EXTENSION_WORKING_DIR%\%BUILD_CONFIGURATION%
 MKDIR %BUILD_OUTPUT%\packages
 
 REM Delete the ref folder so that the zip can be loaded by the SPEES
+REM
 RD /S /Q %BUILD_OUTPUT%\ref
 POPD
 
 REM Define files to compress, conditionally including .pdb files if BUILD_CONFIGURATION is "debug"
+REM
 SET FILES_TO_COMPRESS=%BUILD_OUTPUT%\*.dll, %BUILD_OUTPUT%\Microsoft.SqlServer.CSharpExtension.runtimeconfig.json, %BUILD_OUTPUT%\Microsoft.SqlServer.CSharpExtension.deps.json
 IF /I "%BUILD_CONFIGURATION%"=="debug" (SET FILES_TO_COMPRESS=%FILES_TO_COMPRESS%, %BUILD_OUTPUT%\*.pdb)
 
 REM Package the signed binaries.
 REM
-powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Compress-Archive -Force -Path %FILES_TO_COMPRESS% -DestinationPath %BUILD_OUTPUT%\packages\dotnet-core-CSharp-lang-extension.zip"
+powershell -NoProfile -ExecutionPolicy Unrestricted ^
+ -Command "Compress-Archive -Force -Path %FILES_TO_COMPRESS%" ^
+ "-DestinationPath %BUILD_OUTPUT%\packages\dotnet-core-CSharp-lang-extension.zip"
 CALL :CHECKERROR %ERRORLEVEL% "Error: Failed to create zip for dotnet-core-CSharp-extension for configuration=%BUILD_CONFIGURATION%" || EXIT /b %ERRORLEVEL%
 
 ECHO "Success: Compressed dotnet-core-CSharp-extension for %BUILD_CONFIGURATION% configuration."

--- a/language-extensions/dotnet-core-CSharp/build/windows/create-dotnet-core-CSharp-extension-zip.cmd
+++ b/language-extensions/dotnet-core-CSharp/build/windows/create-dotnet-core-CSharp-extension-zip.cmd
@@ -24,18 +24,18 @@ REM Delete the ref folder so that the zip can be loaded by the SPEES
 RD /S /Q %BUILD_OUTPUT%\ref
 POPD
 
+REM Define files to compress, conditionally including .pdb files if BUILD_CONFIGURATION is "debug"
+SET FILES_TO_COMPRESS=%BUILD_OUTPUT%\*.dll, %BUILD_OUTPUT%\Microsoft.SqlServer.CSharpExtension.runtimeconfig.json, %BUILD_OUTPUT%\Microsoft.SqlServer.CSharpExtension.deps.json
+IF /I "%BUILD_CONFIGURATION%"=="debug" (SET FILES_TO_COMPRESS=%FILES_TO_COMPRESS%, %BUILD_OUTPUT%\*.pdb)
+
 REM Package the signed binaries.
 REM
-powershell -NoProfile -ExecutionPolicy Unrestricted ^
- -Command "Compress-Archive -Force -Path %BUILD_OUTPUT%\*.dll, %BUILD_OUTPUT%\*.pdb, `" ^
- "%BUILD_OUTPUT%\Microsoft.SqlServer.CSharpExtension.runtimeconfig.json, `" ^
- "%BUILD_OUTPUT%\Microsoft.SqlServer.CSharpExtension.deps.json `" ^
- "-DestinationPath %BUILD_OUTPUT%\packages\dotnet-core-CSharp-lang-extension.zip"
+powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Compress-Archive -Force -Path %FILES_TO_COMPRESS% -DestinationPath %BUILD_OUTPUT%\packages\dotnet-core-CSharp-lang-extension.zip"
 CALL :CHECKERROR %ERRORLEVEL% "Error: Failed to create zip for dotnet-core-CSharp-extension for configuration=%BUILD_CONFIGURATION%" || EXIT /b %ERRORLEVEL%
 
 ECHO "Success: Compressed dotnet-core-CSharp-extension for %BUILD_CONFIGURATION% configuration."
 
-REM REM Advance arg passed to create-dotnet-core-CSharp-extension-zip.cmd
+REM Advance arg passed to create-dotnet-core-CSharp-extension-zip.cmd
 REM
 SHIFT
 REM Continue building using more configs until argv has been exhausted
@@ -45,8 +45,8 @@ IF NOT "%~1"=="" GOTO LOOP
 EXIT /b %ERRORLEVEL%
 
 :CHECKERROR
-	IF %1 NEQ 0 (
-		ECHO %2
-		EXIT /b %1
-	)
-	EXIT /b 0
+    IF %1 NEQ 0 (
+        ECHO %2
+        EXIT /b %1
+    )
+    EXIT /b 0


### PR DESCRIPTION
This PR introduces a change to the build process of the C# extension, specifically targeting the release builds. The primary change implemented by this PR is the removal of `.pdb`  files from the release build  of the C# extension.

### Background

PDB files are used to store debugging information about a program or module, such as the names of variables and the lines of code that correspond to machine code instructions. While invaluable for debugging purposes, including them in release builds can unnecessarily increase the size of the deployment package and potentially expose sensitive debugging information in a production environment.

### Changes Implemented

- **Build Script Modification**: The build scripts have been updated to exclude `.pdb` files from the output of the release build process for the C# extension. This adjustment ensures that the release build output is leaner and more secure for production deployment.

- **Impact on Debug Builds**: It's important to note that this change does not affect debug builds. `.pdb` files will continue to be generated and included in debug builds to facilitate development and debugging.




