### PR TITLE
[Java Extension] Rename jar file to mssql-java-lang-extension-linux.jar for linux and remove the jar file from windows zip

### DIFF
--- a/language-extensions/java/README.md
+++ b/language-extensions/java/README.md
@@ -65,7 +65,7 @@ A.	Using the [**restore-packages.sh**](build/linux/restore-packages.sh) script
 
 1. Run [**build-java-extension.sh**](build/linux/build-java-extension.sh) which will generate two main files: \
 		- PATH/TO/ENLISTMENT/build-output/java-extension/linux/release/libJavaExtension.so.1.0 \
-		- PATH/TO/ENLISTMENT/build-output/java-extension/target/release/mssql-java-lang-extension.jar
+		- PATH/TO/ENLISTMENT/build-output/java-extension/target/release/mssql-java-lang-extension-linux.jar
 
 1. Run [**create-java-extension-zip.sh**](build/linux/create-java-extension-zip.sh) which will generate: \
 		- PATH/TO/ENLISTMENT/build-output/java-extension/linux/release/packages/java-lang-extension.zip \

--- a/language-extensions/java/build/linux/build-java-extension.sh
+++ b/language-extensions/java/build/linux/build-java-extension.sh
@@ -19,7 +19,7 @@ function build {
 	#
 	TARGET=${ENL_ROOT}/build-output/java-extension/target/${CMAKE_CONFIGURATION}
 	TARGET_CLASSES=${TARGET}/classes
-	OUTPUT_JAR=mssql-java-lang-extension.jar
+	OUTPUT_JAR=mssql-java-lang-extension-linux.jar
 
 	# Create the output directories
 	#
@@ -32,7 +32,7 @@ function build {
 	ls -d "$PWD"/*.java > ${TARGET}/sources.txt
 	${JAVA_HOME}/bin/javac  -d ${TARGET_CLASSES} @${TARGET}/sources.txt
 
-	# Create the mssql-java-lang-extension.jar file
+	# Create the mssql-java-lang-extension-linux.jar file
 	#
 	${JAVA_HOME}/bin/jar cvf ${TARGET}/${OUTPUT_JAR} -C ${TARGET_CLASSES} .
 
@@ -80,7 +80,7 @@ ENL_ROOT=${SCRIPTDIR}/../../../..
 #
 JAVAEXTENSION_HOME=${ENL_ROOT}/language-extensions/java
 JAVAEXTENSION_WORKING_DIR=${ENL_ROOT}/build-output/java-extension/linux
-DEFAULT_JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+DEFAULT_JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 
 # Find JAVA_HOME from user, or set to default for tests.
 # Error code 1 is generic bash error.

--- a/language-extensions/java/build/windows/create-java-extension-zip.cmd
+++ b/language-extensions/java/build/windows/create-java-extension-zip.cmd
@@ -16,12 +16,11 @@ IF NOT DEFINED BUILD_CONFIGURATION (SET BUILD_CONFIGURATION=release)
 IF /I NOT %BUILD_CONFIGURATION%==debug (SET BUILD_CONFIGURATION=release)
 
 SET BUILD_OUTPUT=%ENL_ROOT%\build-output\java-extension\windows\%BUILD_CONFIGURATION%
-SET OUTPUT_JAR="%ENL_ROOT%\build-output\java-extension\target\%BUILD_CONFIGURATION%\mssql-java-lang-extension.jar"
 
 mkdir %BUILD_OUTPUT%\packages
 
 REM Set common files to be included in the zip
-SET INCLUDE_FILES=%BUILD_OUTPUT%\javaextension.dll, %OUTPUT_JAR%
+SET INCLUDE_FILES=%BUILD_OUTPUT%\javaextension.dll
 
 REM Check if BUILD_CONFIGURATION is debug, then include javaextension.pdb in the zip
 IF /I "%BUILD_CONFIGURATION%"=="debug" (


### PR DESCRIPTION
This PR renames the jar file form mssql-java-lang-extension.jar to mssql-java-lang-extension-linux.jar to differentiate between the windows' jar file. The PR also removes the jar file from the zip package for linux since we plan to release the jar file along with the zip in the Assets so that users do not need to unzip the package to get the jar file.

Small fix: change the default java home to java 17 that is installed during the restore-packages.sh






















































