### PR TITLE
Improve Python `restore-packages.cmd` execution time in pipeline + Fix Build break due to numpy 2.0+

### DIFF
--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -61,7 +61,7 @@ REM powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive
 REM -o Output directory
 REM 2nd param is the file to expand
 echo -- Beginning Boost ZIP extraction -- Time: %time% --
-%ARCHIVE_TOOL_PATH% e -y -o"%PACKAGES_ROOT%" "boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
+%ARCHIVE_TOOL_PATH% e -y -o"%PACKAGES_ROOT%/boost_%BOOST_VERSION_IN_UNDERSCORE%" "boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
 echo -- Finished Boost Zip extration -- Time: %time% --
 
 REM Boost cleanup

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -88,7 +88,6 @@ echo -- Beginning Boost b2.exe build -- Time: %time% --
 CALL bootstrap.bat vc142
 echo -- Beginning Boost build using compiled b2.exe-- Time: %time% --
 b2.exe -j12 --prefix=%PACKAGES_ROOT%\output --with-python --user-config="%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%\user-config.jam" --debug-configuration -dp0 toolset=msvc-14.2
-REM  address-model=64 variant=debug link=static threading=multi runtime-link=shared install
 echo -- Finished Boost build -- Time: %time% --
 
 REM If building in pipeline, set the PYTHONHOME here to overwrite the existing PYTHONHOME

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -4,7 +4,7 @@ CALL %ENL_ROOT%\restore-packages.cmd
 SET PACKAGES_ROOT=%ENL_ROOT%\packages
 
 REM 7zip file extraction tooling - Direct path on pipeline
-SET 7ZIPPATH="C:\Program Files\7-Zip\7z.exe"
+SET 7ZIPPATH="C:\7-Zip\7z.exe"
 
 REM Specify the Python version to be downloaded and installed
 REM

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -43,7 +43,9 @@ curl -sS https://bootstrap.pypa.io/get-pip.py |"%PYTHON_INSTALLATION_PATH%\pytho
 
 REM Install numpy and pandas
 REM
-"%PYTHON_INSTALLATION_PATH%\python.exe" -m pip install pandas numpy
+SET NUMPY_VERSION=1.22.3
+SET PANDAS_VERSION=1.4.2
+"%PYTHON_INSTALLATION_PATH%\python.exe" -m pip install --force-reinstall numpy==%NUMPY_VERSION% pandas==%PANDAS_VERSION%
 
 REM Remove the Python installer which is no longer needed
 REM
@@ -56,7 +58,6 @@ REM Remove the Boost zip file
 REM Navigate to the extracted Boost directory
 REM
 curl -L -o boost_%BOOST_VERSION_IN_UNDERSCORE%.7z https://archives.boost.io/release/%BOOST_VERSION%/source/boost_%BOOST_VERSION_IN_UNDERSCORE%.7z
-REM powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive -Force -Path 'boost_%BOOST_VERSION_IN_UNDERSCORE%.zip' -DestinationPath '%PACKAGES_ROOT%'"
 
 REM -o Output directory
 REM 2nd param is the file to expand
@@ -80,11 +81,14 @@ REM
 echo using python : %PYTHON_VERSION_MAJOR_MINOR% : "%PYTHON_INSTALLATION_PATH_DOUBLE_SLASH%\\python" : "%PYTHON_INSTALLATION_PATH_DOUBLE_SLASH%\\include" : "%PYTHON_INSTALLATION_PATH_DOUBLE_SLASH%\\libs" ; > user-config.jam
 
 REM Run Boost's bootstrap script and build Boost.Python with the created configuration
-REM
+REM Explicitly set VS2019 Compiler tooling 
+REM bootstrap - "vc142"
+REM b2.exe "toolset=msvc-14.2"
 echo -- Beginning Boost b2.exe build -- Time: %time% --
-CALL bootstrap.bat
+CALL bootstrap.bat vc142
 echo -- Beginning Boost build using compiled b2.exe-- Time: %time% --
-b2.exe -j12 --with-python --user-config="%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%\user-config.jam" --debug-configuration -d0
+b2.exe -j12 --prefix=%PACKAGES_ROOT%\output --with-python --user-config="%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%\user-config.jam" --debug-configuration -dp0 toolset=msvc-14.2
+REM  address-model=64 variant=debug link=static threading=multi runtime-link=shared install
 echo -- Finished Boost build -- Time: %time% --
 
 REM If building in pipeline, set the PYTHONHOME here to overwrite the existing PYTHONHOME

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -4,7 +4,7 @@ CALL %ENL_ROOT%\restore-packages.cmd
 SET PACKAGES_ROOT=%ENL_ROOT%\packages
 
 REM 7zip file extraction tooling - Direct path on pipeline
-SET ARCHIVE_TOOL_PATH="C:\Program Files\7-Zip\7z.exe"
+SET ARCHIVE_TOOL_PATH="C:\7-Zip\7z.exe"
 
 REM Specify the Python version to be downloaded and installed
 REM

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -61,7 +61,7 @@ REM powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive
 REM -o Output directory
 REM 2nd param is the file to expand
 echo -- Beginning Boost ZIP extraction -- Time: %time% --
-%ARCHIVE_TOOL_PATH% e -y -o"%PACKAGES_ROOT%" "%PACKAGES_ROOT%/boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
+%ARCHIVE_TOOL_PATH% e -y -o"%PACKAGES_ROOT%" "boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
 echo -- Finished Boost Zip extration -- Time: %time% --
 
 REM Boost cleanup

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -4,7 +4,7 @@ CALL %ENL_ROOT%\restore-packages.cmd
 SET PACKAGES_ROOT=%ENL_ROOT%\packages
 
 REM 7zip file extraction tooling - Direct path on pipeline
-SET 7ZIPPATH="C:\7-Zip\7z.exe"
+SET ARCHIVE_TOOL_PATH=C:\7-Zip\7z.exe
 
 REM Specify the Python version to be downloaded and installed
 REM
@@ -61,7 +61,7 @@ REM powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive
 REM -o Output directory
 REM 2nd param is the file to expand
 echo -- Beginning Boost ZIP extraction -- Time: %time% --
-%7ZIPPATH% e -y -o"%PACKAGES_ROOT%" "%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
+%ARCHIVE_TOOL_PATH% e -y -o"%PACKAGES_ROOT%" "%PACKAGES_ROOT%/boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
 echo -- Finished Boost Zip extration -- Time: %time% --
 
 REM Boost cleanup

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -4,7 +4,7 @@ CALL %ENL_ROOT%\restore-packages.cmd
 SET PACKAGES_ROOT=%ENL_ROOT%\packages
 
 REM 7zip file extraction tooling - Direct path on pipeline
-SET ARCHIVE_TOOL_PATH=C:\7-Zip\7z.exe
+SET ARCHIVE_TOOL_PATH="C:\Program Files\7-Zip\7z.exe"
 
 REM Specify the Python version to be downloaded and installed
 REM
@@ -61,7 +61,7 @@ REM powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive
 REM -o Output directory
 REM 2nd param is the file to expand
 echo -- Beginning Boost ZIP extraction -- Time: %time% --
-%ARCHIVE_TOOL_PATH% e -y -o"%PACKAGES_ROOT%/boost_%BOOST_VERSION_IN_UNDERSCORE%" "boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
+%ARCHIVE_TOOL_PATH% x -y -o"packages" "boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
 echo -- Finished Boost Zip extration -- Time: %time% --
 
 REM Boost cleanup
@@ -74,8 +74,9 @@ echo using python : %PYTHON_VERSION_MAJOR_MINOR% : "%PYTHON_INSTALLATION_PATH_DO
 
 REM Run Boost's bootstrap script and build Boost.Python with the created configuration
 REM
-echo -- Beginning Boost build using b2.exe-- Time: %time% --
+echo -- Beginning Boost b2.exe build -- Time: %time% --
 CALL bootstrap.bat
+echo -- Beginning Boost build using compiled b2.exe-- Time: %time% --
 b2.exe -j12 --with-python --user-config="%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%\user-config.jam" --debug-configuration -d0
 echo -- Finished Boost build -- Time: %time% --
 

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -65,9 +65,15 @@ echo -- Beginning Boost ZIP extraction -- Time: %time% --
 echo -- Finished Boost Zip extration -- Time: %time% --
 
 REM Boost cleanup
+echo Delete 7z boost archive
 del boost_%BOOST_VERSION_IN_UNDERSCORE%.7z
+echo go to dir with boost unarchived
+%cd%
+dir
 pushd %PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%
-
+%cd%
+dir
+echo create user config jam
 REM Create a Boost user-config.jam configuration file for building Boost.Python
 REM
 echo using python : %PYTHON_VERSION_MAJOR_MINOR% : "%PYTHON_INSTALLATION_PATH_DOUBLE_SLASH%\\python" : "%PYTHON_INSTALLATION_PATH_DOUBLE_SLASH%\\include" : "%PYTHON_INSTALLATION_PATH_DOUBLE_SLASH%\\libs" ; > user-config.jam

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -52,7 +52,12 @@ REM Remove the Boost zip file
 REM Navigate to the extracted Boost directory
 REM
 curl -L -o boost_%BOOST_VERSION_IN_UNDERSCORE%.zip https://sourceforge.net/projects/boost/files/boost/%BOOST_VERSION%/boost_%BOOST_VERSION_IN_UNDERSCORE%.zip/download
-powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive -Force -Path 'boost_%BOOST_VERSION_IN_UNDERSCORE%.zip' -DestinationPath '%PACKAGES_ROOT%'"
+REM powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive -Force -Path 'boost_%BOOST_VERSION_IN_UNDERSCORE%.zip' -DestinationPath '%PACKAGES_ROOT%'"
+
+REM -o Output directory
+REM 2nd param is the file to expand
+C:\7-Zip\7z.exe e -y -o"%PACKAGES_ROOT%" "boost_%BOOST_VERSION_IN_UNDERSCORE%.zip"
+
 del boost_%BOOST_VERSION_IN_UNDERSCORE%.zip
 pushd %PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%
 

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -61,17 +61,18 @@ REM powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive
 REM -o Output directory
 REM 2nd param is the file to expand
 echo -- Beginning Boost ZIP extraction -- Time: %time% --
-%ARCHIVE_TOOL_PATH% x -y -o"packages" "boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
+%ARCHIVE_TOOL_PATH% x -y -o"%PACKAGES_ROOT%" "boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
 echo -- Finished Boost Zip extration -- Time: %time% --
 
 REM Boost cleanup
 echo Delete 7z boost archive
 del boost_%BOOST_VERSION_IN_UNDERSCORE%.7z
 echo go to dir with boost unarchived
-%cd%
+echo %cd%
 dir
+echo %PACKAGES_ROOT%
 pushd %PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%
-%cd%
+echo %cd%
 dir
 echo create user config jam
 REM Create a Boost user-config.jam configuration file for building Boost.Python

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -3,6 +3,9 @@ CALL %ENL_ROOT%\restore-packages.cmd
 
 SET PACKAGES_ROOT=%ENL_ROOT%\packages
 
+REM 7zip file extraction tooling - Direct path on pipeline
+SET 7ZIPPATH="C:\Program Files\7-Zip\7z.exe"
+
 REM Specify the Python version to be downloaded and installed
 REM
 SET PYTHON_VERSION=3.10.2
@@ -46,20 +49,23 @@ REM Remove the Python installer which is no longer needed
 REM
 del "python-%PYTHON_VERSION%.exe"
 
+REM BOOST artifact download, extract, build
 REM Download the specified version of Boost from SourceForge
 REM Extract the downloaded Boost zip file to the packages directory
 REM Remove the Boost zip file
 REM Navigate to the extracted Boost directory
 REM
-curl -L -o boost_%BOOST_VERSION_IN_UNDERSCORE%.zip https://sourceforge.net/projects/boost/files/boost/%BOOST_VERSION%/boost_%BOOST_VERSION_IN_UNDERSCORE%.zip/download
+curl -L -o boost_%BOOST_VERSION_IN_UNDERSCORE%.7z https://archives.boost.io/release/%BOOST_VERSION%/source/boost_%BOOST_VERSION_IN_UNDERSCORE%.7z
 REM powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive -Force -Path 'boost_%BOOST_VERSION_IN_UNDERSCORE%.zip' -DestinationPath '%PACKAGES_ROOT%'"
 
 REM -o Output directory
 REM 2nd param is the file to expand
 echo -- Beginning Boost ZIP extraction -- Time: %time% --
-C:\7-Zip\7z.exe e -y -o"%PACKAGES_ROOT%" "boost_%BOOST_VERSION_IN_UNDERSCORE%.zip"
+%7ZIPPATH% e -y -o"%PACKAGES_ROOT%" "%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
 echo -- Finished Boost Zip extration -- Time: %time% --
-del boost_%BOOST_VERSION_IN_UNDERSCORE%.zip
+
+REM Boost cleanup
+del boost_%BOOST_VERSION_IN_UNDERSCORE%.7z
 pushd %PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%
 
 REM Create a Boost user-config.jam configuration file for building Boost.Python
@@ -68,8 +74,10 @@ echo using python : %PYTHON_VERSION_MAJOR_MINOR% : "%PYTHON_INSTALLATION_PATH_DO
 
 REM Run Boost's bootstrap script and build Boost.Python with the created configuration
 REM
+echo -- Beginning Boost build using b2.exe-- Time: %time% --
 CALL bootstrap.bat
 b2.exe -j12 --with-python --user-config="%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%\user-config.jam" --debug-configuration -d0
+echo -- Finished Boost build -- Time: %time% --
 
 REM If building in pipeline, set the PYTHONHOME here to overwrite the existing PYTHONHOME
 REM

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -56,8 +56,9 @@ REM powershell -NoProfile -ExecutionPolicy Unrestricted -Command "Expand-Archive
 
 REM -o Output directory
 REM 2nd param is the file to expand
+echo -- Beginning Boost ZIP extraction -- Time: %time% --
 C:\7-Zip\7z.exe e -y -o"%PACKAGES_ROOT%" "boost_%BOOST_VERSION_IN_UNDERSCORE%.zip"
-
+echo -- Finished Boost Zip extration -- Time: %time% --
 del boost_%BOOST_VERSION_IN_UNDERSCORE%.zip
 pushd %PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%
 


### PR DESCRIPTION
## Why this change?

1. Closes #52 
    - which highlights the lengthy execution time of running **language-extensions/python/build/windows/restore-packages.cmd** in pipelines (and also locally). Pipelines have this step taking ~20 minutes to complete. Essentially, expanding the Boost archive takes a long time on Windows due to the count of files. 

2. Closes #54 
    - which highlights that Numpy v2.0+ isn't supported in current Boost version, causing pipeline build failure for Python extension.

### Background on zip file slowness
Anecdotal data points for :
- https://github.com/Tudat/tudatBundle/issues/10
- https://github.com/boostorg/boost/issues/876

Boost Recommendation not to use ZIP files:
> We recommend downloading [boost_1_79_0.7z](https://www.boost.org/users/history/version_1_79_0.html) and using [7-Zip](http://www.7-zip.org/) to decompress it. We no longer recommend .zip files for Boost because they are twice as large as the equivalent .7z files. We don't recommend using Windows' built-in decompression as it can be painfully slow for large archives. [Ref](https://www.boost.org/doc/libs/1_79_0/more/getting_started/windows.html#test-your-program:~:text=We%20recommend%20downloading%20boost_1_79_0.7z%20and%20using%207%2DZip%20to%20decompress%20it.%20We%20no%20longer%20recommend%20.zip%20files%20for%20Boost%20because%20they%20are%20twice%20as%20large%20as%20the%20equivalent%20.7z%20files.%20We%20don%27t%20recommend%20using%20Windows%27%20built%2Din%20decompression%20as%20it%20can%20be%20painfully%20slow%20for%20large%20archives.)

Perf improvements:
- Before: pipelines average of ~20minute execution time.
![image](https://github.com/microsoft/sql-server-language-extensions/assets/6414189/988292eb-816b-4756-bdad-0b275ba184db)

- Now (**Improved to 5 minutes**)
![image](https://github.com/microsoft/sql-server-language-extensions/assets/6414189/2a0f032b-88e9-415c-8b3f-c51bedf1a049)

## What is this change

1. Updates the URL used to fetch Boost 1.79.0 from sourceforge to archives.boost.io 
4. Downloads a 7z (7zip) archive instead of zip file because performance increase was drastic when testing locally with a 7z file on Windows. (And Boost docs recommend that we use 7z file)
5. Output timestamps before extracting boost (which took 20 minutes) to point out that this was the culprit of slow execution.
6. Added timestamps for building boost so that we can identify duration in pipeline. 
7. Hardcodes Numpy and Pandas dependencies for Python to match the hardcoded versions defined in Linux `restore-packages.sh` script. Support for Numpy 2.0+ in Boosts hasn't made it to official release yet, only in dev branches. more details in #54 
    - Numpy: `1.22.3`
    - Pandas: `1.4.2`

### 7zip command reference
```sh
%ARCHIVE_TOOL_PATH% x -y -o"%PACKAGES_ROOT%" "boost_%BOOST_VERSION_IN_UNDERSCORE%.7z"
```

- `%ARCHIVE_TOOL_PATH%` -> full path to 7zip exe. on pipeline it is a specific path. Local devs will need to update accordingly.
- `x` This is a 7-Zip command that tells 7Zip to extract files from an archive with their full path
- `-y` this option automatically answers yes to any prompts (such as overwrite confirmations).
- `-o` option to specify output directory where the files will be extracted
- `"path"` This is the path to the .7z archive that will be extracted.We recommend downloading [boost_1_82_0.7z](https://www.boost.org/users/history/version_1_82_0.html) and using [7-Zip](http://www.7-zip.org/) to decompress it. We no longer recommend .zip files for Boost because they are twice as large as the equivalent .7z files. We don't recommend using Windows' built-in decompression as it can be painfully slow for large archives.

## How was this tested?
- passed build pipelines