### PR TITLE
CodeQL Fixes - Type Comparison

### DIFF
--- a/language-extensions/R/src/RDataSet.cpp
+++ b/language-extensions/R/src/RDataSet.cpp
@@ -862,7 +862,7 @@ void ROutputDataSet::CleanupColumns()
 {
 	LOG("ROutputDataSet::CleanupColumns");
 
-	for (SQLUSMALLINT columnNumber = 0; columnNumber < m_data.size(); ++columnNumber)
+	for (size_t columnNumber = 0; columnNumber < m_data.size(); ++columnNumber)
 	{
 		SQLSMALLINT dataType = m_columnsDataType[columnNumber];
 

--- a/language-extensions/R/test/src/RExtensionExecuteTests.cpp
+++ b/language-extensions/R/test/src/RExtensionExecuteTests.cpp
@@ -623,7 +623,7 @@ namespace ExtensionApiTest
 			//
 			Rcpp::DataFrame inputDataSet = m_globalEnvironment[m_inputDataNameString.c_str()];
 
-			for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+			for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 			{
 				RVectorType column = inputDataSet[columnNames[columnNumber].c_str()];
 				CheckRVectorColumnDataEquality<SQLType, RVectorType, dataType>(
@@ -686,7 +686,7 @@ namespace ExtensionApiTest
 			//
 			Rcpp::DataFrame inputDataSet = m_globalEnvironment[m_inputDataNameString.c_str()];
 
-			for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+			for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 			{
 				Rcpp::CharacterVector column = inputDataSet[columnNames[columnNumber].c_str()];
 				CheckRCharacterVectorColumnDataEquality<CharType>(
@@ -766,7 +766,7 @@ namespace ExtensionApiTest
 			//
 			Rcpp::DataFrame inputDataSet = m_globalEnvironment[m_inputDataNameString.c_str()];
 
-			for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+			for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 			{
 				RVectorType column = inputDataSet[columnNames[columnNumber].c_str()];
 				CheckRDateTimeVectorColumnDataEquality<SQLType, RVectorType, DateTimeTypeInR>(
@@ -826,7 +826,7 @@ namespace ExtensionApiTest
 		//
 		Rcpp::DataFrame inputDataSet = m_globalEnvironment[m_inputDataNameString.c_str()];
 
-		for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+		for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 		{
 			Rcpp::NumericVector column = inputDataSet[columnNames[columnNumber].c_str()];
 			CheckRVectorColumnDataEquality<SQLDOUBLE, Rcpp::NumericVector, SQL_C_DOUBLE>(

--- a/language-extensions/R/test/src/RExtensionGetOutputParamTests.cpp
+++ b/language-extensions/R/test/src/RExtensionGetOutputParamTests.cpp
@@ -1246,7 +1246,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			SQLPOINTER paramValue = nullptr;
 			SQLINTEGER strLen_or_Ind = 0;
@@ -1306,7 +1306,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			SQLPOINTER paramValue = nullptr;
 			SQLINTEGER strLen_or_Ind = 0;
@@ -1350,7 +1350,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			SQLPOINTER paramValue = nullptr;
 			SQLINTEGER strLen_or_Ind = 0;
@@ -1405,7 +1405,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			SQLPOINTER paramValue = nullptr;
 			SQLINTEGER strLen_or_Ind = 0;
@@ -1450,7 +1450,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-		for (SQLULEN paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			SQLType expectedParamValue = expectedParamValues[paramNumber];
 
@@ -1496,7 +1496,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-		for (SQLULEN paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			SQL_NUMERIC_STRUCT expectedParamValue = expectedParamValues[paramNumber];
 

--- a/language-extensions/R/test/src/RExtensionGetResultsTests.cpp
+++ b/language-extensions/R/test/src/RExtensionGetResultsTests.cpp
@@ -824,7 +824,7 @@ namespace ExtensionApiTest
 		//
 		Rcpp::DataFrame outputDataSet = m_globalEnvironment[m_outputDataNameString.c_str()];
 
-		for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+		for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 		{
 			InputSQLType *expectedColumnData = static_cast<InputSQLType *>(expectedData[columnNumber]);
 			OutputSQLType *columnData = static_cast<OutputSQLType *>(data[columnNumber]);
@@ -944,7 +944,7 @@ namespace ExtensionApiTest
 		//
 		Rcpp::DataFrame outputDataSet = m_globalEnvironment[m_outputDataNameString.c_str()];
 
-		for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+		for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 		{
 			char *expectedColumnData = static_cast<char *>(expectedData[columnNumber]);
 			char *columnData = static_cast<char *>(data[columnNumber]);
@@ -1033,7 +1033,7 @@ namespace ExtensionApiTest
 		//
 		Rcpp::DataFrame outputDataSet = m_globalEnvironment[m_outputDataNameString.c_str()];
 
-		for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+		for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 		{
 			SQLType *expectedColumnData = static_cast<SQLType*>(expectedData[columnNumber]);
 			SQLType *columnData = static_cast<SQLType *>(data[columnNumber]);

--- a/language-extensions/R/test/src/RExtensionInitParamTests.cpp
+++ b/language-extensions/R/test/src/RExtensionInitParamTests.cpp
@@ -612,7 +612,7 @@ namespace ExtensionApiTest
 
 		vector<SQLULEN> precisionAsParamSize(parametersNumber, 0);
 		vector<SQLSMALLINT> decimalDigits(parametersNumber, 0);
-		for (int paramNumber = 0; paramNumber < parametersNumber; ++paramNumber)
+		for (SQLUSMALLINT paramNumber = 0; paramNumber < parametersNumber; ++paramNumber)
 		{
 			precisionAsParamSize[paramNumber] = inputNumericValues[paramNumber].precision;
 			decimalDigits[paramNumber] = inputNumericValues[paramNumber].scale;
@@ -830,7 +830,7 @@ namespace ExtensionApiTest
 		vector<SQLSMALLINT>         inputOutputTypes,
 		bool                        validate)
 	{
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			string paramNameString = string("@param" + to_string(paramNumber + 1));
 			SQLCHAR *paramName = static_cast<SQLCHAR*>(
@@ -894,7 +894,7 @@ namespace ExtensionApiTest
 		bool                    validate,
 		bool                    expectSuccess)
 	{
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			string paramNameString = string("@param" + to_string(paramNumber + 1));
 			SQLCHAR *paramName = static_cast<SQLCHAR*>(
@@ -1019,7 +1019,7 @@ namespace ExtensionApiTest
 		vector<SQLSMALLINT> inputOutputTypes,
 		bool                validate)
 	{
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			string paramNameString = string("@param" + to_string(paramNumber + 1));
 			SQLCHAR *paramName = static_cast<SQLCHAR*>(
@@ -1081,7 +1081,7 @@ namespace ExtensionApiTest
 		vector<SQLSMALLINT> inputOutputTypes,
 		bool                validate)
 	{
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			string paramNameString = string("@param" + to_string(paramNumber + 1));
 			SQLCHAR *paramName = static_cast<SQLCHAR*>(
@@ -1132,7 +1132,7 @@ namespace ExtensionApiTest
 		vector<SQLSMALLINT>        decimalDigits,
 		vector<double>             expectedParamValues)
 	{
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < initParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < initParamValues.size(); ++paramNumber)
 		{
 			string paramNameString = string("@param" + to_string(paramNumber + 1));
 			SQLCHAR *paramName = static_cast<SQLCHAR*>(

--- a/language-extensions/dotnet-core-CSharp/test/src/native/CSharpGetOutputParamTests.cpp
+++ b/language-extensions/dotnet-core-CSharp/test/src/native/CSharpGetOutputParamTests.cpp
@@ -445,7 +445,7 @@ namespace ExtensionApiTest
         vector<bool> isFixedType = { true, false, true, false, true, true };
         vector<SQLULEN> paramSizes = { 5, 6, 10, 5, 5, 5 };
 
-        for(SQLULEN paramNumber=0; paramNumber < paramSizes.size(); ++paramNumber)
+        for(size_t paramNumber=0; paramNumber < paramSizes.size(); ++paramNumber)
         {
             InitStringParameter(
                 paramNumber,
@@ -521,7 +521,7 @@ namespace ExtensionApiTest
     {
         ASSERT_EQ(expectedParamValueVector.size(), expectedStrLenOrIndVector.size());
 
-        for(SQLULEN i = 0; i < expectedParamValueVector.size(); ++i)
+        for(size_t i = 0; i < expectedParamValueVector.size(); ++i)
         {
             SQLType *expectedParamValue = expectedParamValueVector[i];
             SQLINTEGER expectedStrLenOrInd = expectedStrLenOrIndVector[i];
@@ -565,7 +565,7 @@ namespace ExtensionApiTest
     {
         ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-        for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+        for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
         {
             SQLPOINTER paramValue = nullptr;
             SQLINTEGER strLen_or_Ind = 0;

--- a/language-extensions/dotnet-core-CSharp/test/src/native/CSharpGetResultsTests.cpp
+++ b/language-extensions/dotnet-core-CSharp/test/src/native/CSharpGetResultsTests.cpp
@@ -322,7 +322,7 @@ namespace ExtensionApiTest
 
         // Test data obtained is same as the expectedData and the OutputDataSet.
         //
-        for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+        for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
         {
             SQLINTEGER *expectedColumnStrLenOrInd = expectedStrLen_or_Ind[columnNumber];
             SQLINTEGER *columnStrLenOrInd = strLen_or_Ind[columnNumber];
@@ -419,7 +419,7 @@ namespace ExtensionApiTest
 
         EXPECT_EQ(rowsNumber, expectedRowsNumber);
 
-        for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+        for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
         {
             char *expectedColumnData = static_cast<char *>(expectedData[columnNumber]);
             char *columnData = static_cast<char *>(data[columnNumber]);

--- a/language-extensions/python/src/PythonDataSet.cpp
+++ b/language-extensions/python/src/PythonDataSet.cpp
@@ -879,7 +879,7 @@ void PythonOutputDataSet::RetrieveColumnsFromDataFrame()
 
 	bp::list columnNames = GetColumnNames();
 
-	for (SQLUSMALLINT columnNumber = 0; columnNumber < bp::len(columnNames); columnNumber++)
+	for (long columnNumber = 0; columnNumber < bp::len(columnNames); columnNumber++)
 	{
 		string columnName = bp::extract<string>(bp::str(columnNames[columnNumber]));
 		SQLSMALLINT dataType = m_columnsDataType[columnNumber];
@@ -1527,7 +1527,7 @@ void PythonOutputDataSet::CleanupColumns()
 {
 	LOG("PythonOutputDataSet::CleanupColumns");
 
-	for (SQLUSMALLINT columnNumber = 0; columnNumber < m_data.size(); ++columnNumber)
+	for (size_t columnNumber = 0; columnNumber < m_data.size(); ++columnNumber)
 	{
 		SQLSMALLINT dataType = m_columnsDataType[columnNumber];
 

--- a/language-extensions/python/test/src/PythonExecuteTests.cpp
+++ b/language-extensions/python/test/src/PythonExecuteTests.cpp
@@ -577,7 +577,7 @@ namespace ExtensionApiTest
 				createDictScript = m_outputDataNameString + ".to_dict()";
 				bp::dict outputDataSet = bp::extract<bp::dict>(bp::eval(createDictScript.c_str(), m_mainNamespace));
 
-				for (SQLUSMALLINT columnIndex = 0; columnIndex < columnNames.size(); columnIndex++)
+				for (size_t columnIndex = 0; columnIndex < columnNames.size(); columnIndex++)
 				{
 					bp::dict inputColumnToTest = bp::extract<bp::dict>(inputDataSet.get(columnNames[columnIndex]));
 					bp::dict outputColumnToTest = bp::extract<bp::dict>(outputDataSet.get(columnNames[columnIndex]));

--- a/language-extensions/python/test/src/PythonGetOutputParamTests.cpp
+++ b/language-extensions/python/test/src/PythonGetOutputParamTests.cpp
@@ -513,7 +513,7 @@ namespace ExtensionApiTest
 		vector<bool> isFixedType = { true, false, true, false, true, true, false };
 		vector<SQLULEN> paramSizes = { 5, 6, 10, 5, USHRT_MAX, 5, 5 };
 
-		for(SQLULEN paramNumber=0; paramNumber < paramSizes.size(); ++paramNumber)
+		for(size_t paramNumber=0; paramNumber < paramSizes.size(); ++paramNumber)
 		{
 			TestStringParameter(
 				paramNumber,
@@ -621,7 +621,7 @@ namespace ExtensionApiTest
 		vector<bool> isFixedType = { true, false, true , true, true, false, true, false};
 		vector<SQLULEN> paramSizes = { 5, 6, 5, 10, 2, 5, 5, USHRT_MAX };
 
-		for (SQLULEN paramNumber = 0; paramNumber < paramSizes.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < paramSizes.size(); ++paramNumber)
 		{
 			TestWStringParameter(
 				paramNumber,
@@ -714,7 +714,7 @@ namespace ExtensionApiTest
 		vector<bool> isFixedType = { true, false, true, true, false, false, true };
 		vector<SQLULEN> paramSizes = { 5, 6, 5, 10, USHRT_MAX, 5, 5 };
 
-		for (SQLULEN paramNumber = 0; paramNumber < paramSizes.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < paramSizes.size(); ++paramNumber)
 		{
 			vector<SQLCHAR> dummy = { 0x00 };
 
@@ -1019,7 +1019,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValueVector.size(), expectedStrLenOrIndVector.size());
 
-		for(SQLULEN i=0; i< expectedParamValueVector.size(); ++i)
+		for(size_t i=0; i< expectedParamValueVector.size(); ++i)
 		{
 			SQLType *expectedParamValue = expectedParamValueVector[i];
 			SQLINTEGER expectedStrLenOrInd = expectedStrLenOrIndVector[i];
@@ -1062,7 +1062,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			SQLPOINTER paramValue = nullptr;
 			SQLINTEGER strLen_or_Ind = 0;
@@ -1107,7 +1107,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			SQLPOINTER paramValue = nullptr;
 			SQLINTEGER strLen_or_Ind = 0;
@@ -1161,7 +1161,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValues.size(), expectedStrLenOrInd.size());
 
-		for (SQLUSMALLINT paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
+		for (size_t paramNumber = 0; paramNumber < expectedParamValues.size(); ++paramNumber)
 		{
 			SQLPOINTER paramValue = nullptr;
 			SQLINTEGER strLen_or_Ind = 0;
@@ -1206,7 +1206,7 @@ namespace ExtensionApiTest
 	{
 		ASSERT_EQ(expectedParamValueVector.size(), expectedStrLenOrIndVector.size());
 
-		for (SQLULEN i = 0; i < expectedParamValueVector.size(); ++i)
+		for (size_t i = 0; i < expectedParamValueVector.size(); ++i)
 		{
 			DateTimeStruct *expectedParamValue = expectedParamValueVector[i];
 			SQLINTEGER expectedStrLenOrInd = expectedStrLenOrIndVector[i];

--- a/language-extensions/python/test/src/PythonGetResultsTests.cpp
+++ b/language-extensions/python/test/src/PythonGetResultsTests.cpp
@@ -809,7 +809,7 @@ namespace ExtensionApiTest
 		bp::dict outputDataSet = bp::extract<bp::dict>(
 			bp::eval(createDictScript.c_str(), m_mainNamespace));
 
-		for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+		for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 		{
 			bp::dict column = bp::extract<bp::dict>(outputDataSet[columnNames[columnNumber]]);
 
@@ -994,7 +994,7 @@ namespace ExtensionApiTest
 		bp::dict outputDataSet = bp::extract<bp::dict>(
 			bp::eval(createDictScript.c_str(), m_mainNamespace));
 
-		for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+		for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 		{
 			char *expectedColumnData = static_cast<char *>(expectedData[columnNumber]);
 			char *columnData = static_cast<char *>(data[columnNumber]);
@@ -1094,7 +1094,7 @@ namespace ExtensionApiTest
 		bp::dict outputDataSet = bp::extract<bp::dict>(
 			bp::eval(createDictScript.c_str(), m_mainNamespace));
 
-		for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+		for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 		{
 			SQLCHAR *expectedColumnData = static_cast<SQLCHAR *>(expectedData[columnNumber]);
 			SQLCHAR *columnData = static_cast<SQLCHAR *>(data[columnNumber]);
@@ -1196,7 +1196,7 @@ namespace ExtensionApiTest
 		bp::dict outputDataSet = bp::extract<bp::dict>(
 			bp::eval(createDictScript.c_str(), m_mainNamespace));
 
-		for (SQLUSMALLINT columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
+		for (size_t columnNumber = 0; columnNumber < columnNames.size(); ++columnNumber)
 		{
 			bp::dict column = bp::extract<bp::dict>(outputDataSet[columnNames[columnNumber]]);
 


### PR DESCRIPTION
## Why is this change being made?
CodeQL identified some type comparison issues which could result in potential failures.

## What does the change do?
This change makes modifications to the code to ensure that type comparison is done between valid types, removing the potential for failures.

This branch has been put through the language-extensions pipeline run and was built successfully. Additionally, existing tests remain passing.