### PR TITLE
Fix breaking pipeline build - python and dotnet issues

### DIFF
--- a/language-extensions/dotnet-core-CSharp/README.md
+++ b/language-extensions/dotnet-core-CSharp/README.md
@@ -18,14 +18,16 @@ To use this dotnet-core-CSharp-lang-extension.zip package, follow [this tutorial
 
 2. Run [restore-packages.cmd](./build/windows/restore-packages.cmd) which will restore the packages needed for the extension
 
-3. Run [build-dotnet-core-CSharp-extension.cmd](./build/windows/build-dotnet-core-CSharp-extension.cmd) which will generate: \
+3. Run 'dotnet restore <PATH\TO\ENLISTMENT\language-extensions\dotnet-core-CSharp\src\managed\Microsoft.SqlServer.CSharpExtension.csproj\Microsoft.SqlServer.CSharpExtension.csproj>'
+
+4. Run [build-dotnet-core-CSharp-extension.cmd](./build/windows/build-dotnet-core-CSharp-extension.cmd) which will generate: \
         - PATH\TO\ENLISTMENT\build-output\dotnet-core-CSharp-extension\windows\release\nativecsharpextension.dll \
         - PATH\TO\ENLISTMENT\build-output\dotnet-core-CSharp-extension\windows\release\hostfxr.dll \
         - PATH\TO\ENLISTMENT\build-output\dotnet-core-CSharp-extension\windows\release\Microsoft.SqlServer.CSharpExtension.dll \
         - PATH\TO\ENLISTMENT\build-output\dotnet-core-CSharp-extension\windows\release\Microsoft.SqlServer.CSharpExtension.runtimeconfig.json\
         - PATH\TO\ENLISTMENT\build-output\dotnet-core-CSharp-extension\windows\release\Microsoft.SqlServer.CSharpExtension.deps.json
 
-4. Run [create-dotnet-core-CSharp-extension-zip.cmd](./build/windows/create-dotnet-core-CSharp-extension-zip.cmd) which will generate: \
+5. Run [create-dotnet-core-CSharp-extension-zip.cmd](./build/windows/create-dotnet-core-CSharp-extension-zip.cmd) which will generate: \
         - PATH\TO\ENLISTMENT\build-output\dotnet-core-CSharp-extension\target\debug\dotnet-core-CSharp-lang-extension.zip
         This zip can be used in CREATE EXTERNAL LANGUAGE, as detailed in the tutorial in the Usage section below.
 

--- a/language-extensions/dotnet-core-CSharp/build/windows/restore-packages.cmd
+++ b/language-extensions/dotnet-core-CSharp/build/windows/restore-packages.cmd
@@ -2,16 +2,12 @@
 SETLOCAL
 
 SET ENL_ROOT=%~dp0..\..\..\..
-SET DOTNET_EXTENSION_HOME=%ENL_ROOT%\language-extensions\dotnet-core-CSharp
-SET DOTNET_MANAGED_SRC=%DOTNET_EXTENSION_HOME%\src\managed
 
 REM Call the root level restore-packages
 REM
 SET PACKAGES_ROOT=%ENL_ROOT%\packages
 CALL %ENL_ROOT%\restore-packages.cmd
 CALL :CHECKERROR %ERRORLEVEL% "Error: Failed to restore common nuget packages." || EXIT /b %ERRORLEVEL%
-
-dotnet restore %DOTNET_MANAGED_SRC%\Microsoft.SqlServer.CSharpExtension.csproj
 
 EXIT /b %ERRORLEVEL%
 

--- a/language-extensions/python/build/windows/build-python-extension.cmd
+++ b/language-extensions/python/build/windows/build-python-extension.cmd
@@ -18,6 +18,15 @@ SET DEFAULT_BOOST_PYTHON_ROOT=%DEFAULT_BOOST_ROOT%\stage\lib
 SET DEFAULT_PYTHONHOME=C:\Python310
 SET DEFAULT_CMAKE_ROOT=%PACKAGES_ROOT%\CMake-win64.3.15.5
 
+REM Set default python home if python is installed in a different location.
+REM
+for /f "tokens=1 delims=" %%i in ('where python') do (
+	set "DEFAULT_PYTHONHOME=%%~dpi"
+	goto continue
+)
+
+:continue
+
 REM Find boost, python, and cmake paths from user, or set to default for tests.
 REM
 SET ENVVAR_NOT_FOUND=203
@@ -106,7 +115,7 @@ CALL "%CMAKE_ROOT%\bin\cmake.exe" ^
 	-DPYTHONHOME="%PYTHONHOME%" ^
 	-DBOOST_ROOT="%BOOST_ROOT%" ^
 	-DBOOST_PYTHON_ROOT="%BOOST_PYTHON_ROOT%" ^
-	%PYTHONEXTENSION_HOME%/src
+	%PYTHONEXTENSION_HOME%\src
 
 CALL :CHECKERROR %ERRORLEVEL% "Error: Failed to generate make files for CMAKE_CONFIGURATION=%CMAKE_CONFIGURATION%" || EXIT /b %ERRORLEVEL%
 

--- a/language-extensions/python/build/windows/build-python-extension.cmd
+++ b/language-extensions/python/build/windows/build-python-extension.cmd
@@ -18,14 +18,12 @@ SET DEFAULT_BOOST_PYTHON_ROOT=%DEFAULT_BOOST_ROOT%\stage\lib
 SET DEFAULT_PYTHONHOME=C:\Python310
 SET DEFAULT_CMAKE_ROOT=%PACKAGES_ROOT%\CMake-win64.3.15.5
 
-REM Set default python home if python is installed in a different location.
+REM If building in pipeline, Python is installed with `UsePythonVersion@0` task.
+REM This value is stored in PYTHONLOCATION in previous steps.
 REM
-for /f "tokens=1 delims=" %%i in ('where python') do (
-	set "DEFAULT_PYTHONHOME=%%~dpi"
-	goto continue
+if NOT "%PYTHONLOCATION%"=="" (
+	SET DEFAULT_PYTHONHOME=%PYTHONLOCATION%
 )
-
-:continue
 
 REM Find boost, python, and cmake paths from user, or set to default for tests.
 REM

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -1,3 +1,5 @@
+SETLOCAL ENABLEDELAYEDEXPANSION
+
 SET ENL_ROOT=%~dp0..\..\..\..
 CALL %ENL_ROOT%\restore-packages.cmd
 
@@ -21,34 +23,31 @@ REM Download and install Python from the official Python website
 REM
 SET PYTHON_DOWNLOAD_URL="https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-amd64.exe"
 
-REM Set default python home if python is installed.
+REM If building in pipeline, Python is installed with `UsePythonVersion@0` task.
+REM We pass in the path to python installation when this script is called.
+REM Set PYTHON_INSTALLATION_PATH to the output from the task.
 REM
-for /f "tokens=1 delims=" %%i in ('where python') do (
-	SET PYTHON_PATH=%%~dpi
-	goto continue
-)
-
-:continue
-IF NOT DEFINED PYTHON_PATH (
+if "%1"=="" (
 	REM Download and install Python using curl
 	REM
-	curl %PYTHON_DOWNLOAD_URL% -o "python-%PYTHON_VERSION%.exe"
+	curl !PYTHON_DOWNLOAD_URL! -o "python-!PYTHON_VERSION!.exe"
 
-	SET PYTHON_INSTALLATION_PATH=C:\Python%PYTHON_VERSION_NO_DOT%
+	SET PYTHON_INSTALLATION_PATH=C:\Python!PYTHON_VERSION_NO_DOT!
 
 	REM Run the installer in quiet mode, install for all users, prepend Python to PATH, and specify installation directory
 	REM
-	"python-%PYTHON_VERSION%.exe" /quiet InstallAllUsers=1 PrependPath=1 TargetDir="%PYTHON_INSTALLATION_PATH%"
+	"python-!PYTHON_VERSION!.exe" /quiet InstallAllUsers=1 PrependPath=1 TargetDir="!PYTHON_INSTALLATION_PATH!"
 
 	REM Download and install pip
 	REM
-	curl -sS https://bootstrap.pypa.io/get-pip.py |"%PYTHON_INSTALLATION_PATH%\python.exe"
+	curl -sS https://bootstrap.pypa.io/get-pip.py |"!PYTHON_INSTALLATION_PATH!\python.exe"
 
 	REM Remove the Python installer which is no longer needed
 	REM
-	del "python-%PYTHON_VERSION%.exe"
+	del "python-!PYTHON_VERSION!.exe"
 ) ELSE (
-	SET "PYTHON_INSTALLATION_PATH=%PYTHON_PATH:~0,-1%"
+	SET PYTHON_INSTALLATION_PATH=%1
+	SETX PYTHONLOCATION %PYTHON_INSTALLATION_PATH%
 )
 
 SET "PYTHON_INSTALLATION_PATH_DOUBLE_SLASH=%PYTHON_INSTALLATION_PATH:\=\\%"

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -28,9 +28,6 @@ for /f "tokens=1 delims=" %%i in ('where python') do (
 	goto continue
 )
 
-echo Write all the python paths to the console
-echo %PYTHON_PATH%
-
 :continue
 IF NOT DEFINED PYTHON_PATH (
 	REM Download and install Python using curl
@@ -53,8 +50,6 @@ IF NOT DEFINED PYTHON_PATH (
 ) ELSE (
 	SET "PYTHON_INSTALLATION_PATH=%PYTHON_PATH:~0,-1%"
 )
-
-echo Python installation path: %PYTHON_INSTALLATION_PATH%
 
 SET "PYTHON_INSTALLATION_PATH_DOUBLE_SLASH=%PYTHON_INSTALLATION_PATH:\=\\%"
 

--- a/language-extensions/python/test/build/windows/build-pythonextension-test.cmd
+++ b/language-extensions/python/test/build/windows/build-pythonextension-test.cmd
@@ -19,14 +19,12 @@ SET DEFAULT_BOOST_PYTHON_ROOT=%DEFAULT_BOOST_ROOT%\stage\lib
 SET DEFAULT_PYTHONHOME=C:\Python310
 SET DEFAULT_CMAKE_ROOT=%PACKAGES_ROOT%\CMake-win64.3.15.5
 
-REM Set default python home if python is installed in a different location.
+REM If building in pipeline, Python is installed with `UsePythonVersion@0` task.
+REM This value is stored in PYTHONLOCATION in previous steps.
 REM
-for /f "tokens=1 delims=" %%i in ('where python') do (
-	set DEFAULT_PYTHONHOME=%%~dpi
-	goto continue
+if NOT "%PYTHONLOCATION%"=="" (
+	SET DEFAULT_PYTHONHOME=%PYTHONLOCATION%
 )
-
-:continue
 
 REM Find boost, python, and cmake paths from user, or set to default for tests.
 REM

--- a/language-extensions/python/test/build/windows/build-pythonextension-test.cmd
+++ b/language-extensions/python/test/build/windows/build-pythonextension-test.cmd
@@ -19,6 +19,15 @@ SET DEFAULT_BOOST_PYTHON_ROOT=%DEFAULT_BOOST_ROOT%\stage\lib
 SET DEFAULT_PYTHONHOME=C:\Python310
 SET DEFAULT_CMAKE_ROOT=%PACKAGES_ROOT%\CMake-win64.3.15.5
 
+REM Set default python home if python is installed in a different location.
+REM
+for /f "tokens=1 delims=" %%i in ('where python') do (
+	set DEFAULT_PYTHONHOME=%%~dpi
+	goto continue
+)
+
+:continue
+
 REM Find boost, python, and cmake paths from user, or set to default for tests.
 REM
 SET ENVVAR_NOT_FOUND=203


### PR DESCRIPTION
## Why is this change being made?
In the build pipeline, downloading python executable is not allowed. However, the python executable can be gotten using `UsePythonVersion` devops task. We need to modify the build scripts to utilize the provided executable, while also ensuring that the scripts are usable outside of the pipeline environment.

## What does the change do?
- Update the build script to check if python installation exists in the environment. If it does, this is set as the python path and execution continues, otherwise, we install python and the needed resources and continue with execution.
- `restore-packages.cmd` for dotnetcore has been updated such that it does not restore `Microsoft.SqlServer.CSharpExtension.csproj`. This is now a pipeline task due to pipeline limitations. However, to ensure that non-pipeline runs do not omit this build step, the `readme` has been updated to reflect and include the additional step.

## Test
These changes have been run on all the relevant pipelines and confirmed to be passing.