### PR TITLE
Fix Component Governance false alerts from Boost library sources

### DIFF
--- a/language-extensions/python/build/linux/restore-packages.sh
+++ b/language-extensions/python/build/linux/restore-packages.sh
@@ -17,7 +17,7 @@ PYTHON_VERSION=3.12
 NUMPY_VERSION=2.3.0
 PANDAS_VERSION=2.3.0
 
-apt-get install -y python3.12-dev python3.12 libpython3.12 libpython3.12-dev libboost-all-dev
+apt-get install -y python3.12-dev python3.12 libpython3.12 libpython3.12-dev
 curl -sS https://bootstrap.pypa.io/get-pip.py | /usr/bin/python${PYTHON_VERSION}
 
 # Find PYTHONHOME from user, or set to default for tests.

--- a/language-extensions/python/build/linux/restore-packages.sh
+++ b/language-extensions/python/build/linux/restore-packages.sh
@@ -62,6 +62,27 @@ sed -i 's/using gcc[^;]*;/using gcc : foo : g++ : <cxxflags>-fPIC ;/g' project-c
 
 cp -rf boost /usr/local/include/
 
+# Remove unused Boost library sources to avoid false Component Governance alerts.
+# Only boost_python and boost_numpy are compiled (b2 --with-python).
+# Headers under boost/ at the root are kept since they are needed at compile time.
+# This runs after the build so that Jamfiles are available for b2's dependency resolution.
+#
+BOOST_LIBS_DIR=/usr/local/lib/boost_${BOOST_VERSION_IN_UNDERSCORE}/libs
+if [ -d "${BOOST_LIBS_DIR}" ]; then
+	echo "-- Removing unused Boost library sources --"
+	pushd "${BOOST_LIBS_DIR}"
+	for dir in */; do
+		case "${dir%/}" in
+			python|numpy|headers) ;;
+			*) rm -rf "$dir" ;;
+		esac
+	done
+	popd
+	echo "-- Finished removing unused Boost library sources --"
+else
+	echo "WARNING: Boost libs directory not found at ${BOOST_LIBS_DIR}, skipping cleanup."
+fi
+
 popd
 
 exit $?

--- a/language-extensions/python/build/linux/restore-packages.sh
+++ b/language-extensions/python/build/linux/restore-packages.sh
@@ -17,7 +17,7 @@ PYTHON_VERSION=3.12
 NUMPY_VERSION=2.3.0
 PANDAS_VERSION=2.3.0
 
-apt-get install -y python3.12-dev python3.12 libpython3.12 libpython3.12-dev
+apt-get install -y python3.12-dev python3.12 libpython3.12 libpython3.12-dev libboost-all-dev
 curl -sS https://bootstrap.pypa.io/get-pip.py | /usr/bin/python${PYTHON_VERSION}
 
 # Find PYTHONHOME from user, or set to default for tests.
@@ -57,34 +57,10 @@ echo "using python : ${PYTHON_VERSION} : ${PYTHONHOME}/bin/python${PYTHON_VERSIO
 sed -i 's/using gcc[^;]*;/using gcc : foo : g++ : <cxxflags>-fPIC ;/g' project-config.jam 
 
 ./b2 --clean
-# Build only boost_python and boost_numpy in both debug and release variants,
-# and both static and shared libraries. The numpy include path is required so
-# that b2 can find numpy/arrayobject.h and actually compile boost_numpy.
-NUMPY_INCLUDE=$(${PYTHONHOME}/bin/python${PYTHON_VERSION} -c "import numpy; print(numpy.get_include())")
-./b2 --with-python toolset=gcc variant=debug,release address-model=64 include=${PYTHONHOME}/include/python${PYTHON_VERSION}/ include=${NUMPY_INCLUDE} link=shared,static threading=multi -j12
+# Build both debug and release variants, and both static and shared libraries
+./b2 toolset=gcc variant=debug,release address-model=64 include=${PYTHONHOME}/include/python${PYTHON_VERSION}/ link=shared,static threading=multi -j12
 
 cp -rf boost /usr/local/include/
-
-# Remove unused Boost library sources to avoid false Component Governance alerts.
-# Only boost_python and boost_numpy are compiled (b2 --with-python).
-# Headers under boost/ at the root are kept since they are needed at compile time.
-# This runs after the build so that Jamfiles are available for b2's dependency resolution.
-#
-BOOST_LIBS_DIR=/usr/local/lib/boost_${BOOST_VERSION_IN_UNDERSCORE}/libs
-if [ -d "${BOOST_LIBS_DIR}" ]; then
-	echo "-- Removing unused Boost library sources --"
-	pushd "${BOOST_LIBS_DIR}"
-	for dir in */; do
-		case "${dir%/}" in
-			python|numpy|headers) ;;
-			*) rm -rf "$dir" ;;
-		esac
-	done
-	popd
-	echo "-- Finished removing unused Boost library sources --"
-else
-	echo "WARNING: Boost libs directory not found at ${BOOST_LIBS_DIR}, skipping cleanup."
-fi
 
 popd
 

--- a/language-extensions/python/build/linux/restore-packages.sh
+++ b/language-extensions/python/build/linux/restore-packages.sh
@@ -57,9 +57,11 @@ echo "using python : ${PYTHON_VERSION} : ${PYTHONHOME}/bin/python${PYTHON_VERSIO
 sed -i 's/using gcc[^;]*;/using gcc : foo : g++ : <cxxflags>-fPIC ;/g' project-config.jam 
 
 ./b2 --clean
-# Build only boost_python (which implicitly includes boost_numpy) in both debug and release variants,
-# and both static and shared libraries.
-./b2 --with-python toolset=gcc variant=debug,release address-model=64 include=${PYTHONHOME}/include/python${PYTHON_VERSION}/ link=shared,static threading=multi -j12
+# Build only boost_python and boost_numpy in both debug and release variants,
+# and both static and shared libraries. The numpy include path is required so
+# that b2 can find numpy/arrayobject.h and actually compile boost_numpy.
+NUMPY_INCLUDE=$(${PYTHONHOME}/bin/python${PYTHON_VERSION} -c "import numpy; print(numpy.get_include())")
+./b2 --with-python toolset=gcc variant=debug,release address-model=64 include=${PYTHONHOME}/include/python${PYTHON_VERSION}/ include=${NUMPY_INCLUDE} link=shared,static threading=multi -j12
 
 cp -rf boost /usr/local/include/
 

--- a/language-extensions/python/build/linux/restore-packages.sh
+++ b/language-extensions/python/build/linux/restore-packages.sh
@@ -57,8 +57,9 @@ echo "using python : ${PYTHON_VERSION} : ${PYTHONHOME}/bin/python${PYTHON_VERSIO
 sed -i 's/using gcc[^;]*;/using gcc : foo : g++ : <cxxflags>-fPIC ;/g' project-config.jam 
 
 ./b2 --clean
-# Build both debug and release variants, and both static and shared libraries
-./b2 toolset=gcc variant=debug,release address-model=64 include=${PYTHONHOME}/include/python${PYTHON_VERSION}/ link=shared,static threading=multi -j12
+# Build only boost_python (which implicitly includes boost_numpy) in both debug and release variants,
+# and both static and shared libraries.
+./b2 --with-python toolset=gcc variant=debug,release address-model=64 include=${PYTHONHOME}/include/python${PYTHON_VERSION}/ link=shared,static threading=multi -j12
 
 cp -rf boost /usr/local/include/
 

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -114,20 +114,23 @@ REM Remove unused Boost library sources to avoid false Component Governance aler
 REM Only boost_python and boost_numpy are compiled (b2 --with-python).
 REM Headers under boost/ at the root are kept since they are needed at compile time.
 REM This runs after the build so that Jamfiles are available for b2's dependency resolution.
+REM Only performed in CI pipelines to avoid affecting local/customer environments.
 REM
-SET BOOST_LIBS_DIR=%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%\libs
-IF EXIST "%BOOST_LIBS_DIR%" (
-	echo -- Removing unused Boost library sources -- Time: !time! --
-	pushd "%BOOST_LIBS_DIR%"
-	for /d %%D in (*) do (
-		if /I not "%%D"=="python" if /I not "%%D"=="numpy" if /I not "%%D"=="headers" (
-			RMDIR /s /q "%%D"
+if NOT "%BUILD_BUILDID%"=="" (
+	SET BOOST_LIBS_DIR=%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%\libs
+	IF EXIST "!BOOST_LIBS_DIR!" (
+		echo -- Removing unused Boost library sources -- Time: !time! --
+		pushd "!BOOST_LIBS_DIR!"
+		for /d %%D in (*) do (
+			if /I not "%%D"=="python" if /I not "%%D"=="numpy" if /I not "%%D"=="headers" (
+				RMDIR /s /q "%%D"
+			)
 		)
+		popd
+		echo -- Finished removing unused Boost library sources -- Time: !time! --
+	) ELSE (
+		echo WARNING: Boost libs directory not found at !BOOST_LIBS_DIR!, skipping cleanup.
 	)
-	popd
-	echo -- Finished removing unused Boost library sources -- Time: !time! --
-) ELSE (
-	echo WARNING: Boost libs directory not found at %BOOST_LIBS_DIR%, skipping cleanup.
 )
 
 REM If building in pipeline, set the PYTHONHOME here to overwrite the existing PYTHONHOME

--- a/language-extensions/python/build/windows/restore-packages.cmd
+++ b/language-extensions/python/build/windows/restore-packages.cmd
@@ -80,6 +80,7 @@ echo -- Finished Boost Zip extration -- Time: %time% --
 REM Boost cleanup
 echo Delete 7z boost archive
 del boost_%BOOST_VERSION_IN_UNDERSCORE%.7z
+
 echo go to dir with boost unarchived
 echo %cd%
 dir
@@ -108,6 +109,26 @@ echo using python : %PYTHON_VERSION_MAJOR_MINOR% : "%PYTHON_INSTALLATION_PATH_DO
 echo -- Beginning Boost build using compiled b2.exe -- Time: %time% --
 b2.exe -j12 --with-python toolset=msvc-14.2 address-model=64 link=static,shared threading=multi
 echo -- Finished Boost build -- Time: %time% --
+
+REM Remove unused Boost library sources to avoid false Component Governance alerts.
+REM Only boost_python and boost_numpy are compiled (b2 --with-python).
+REM Headers under boost/ at the root are kept since they are needed at compile time.
+REM This runs after the build so that Jamfiles are available for b2's dependency resolution.
+REM
+SET BOOST_LIBS_DIR=%PACKAGES_ROOT%\boost_%BOOST_VERSION_IN_UNDERSCORE%\libs
+IF EXIST "%BOOST_LIBS_DIR%" (
+	echo -- Removing unused Boost library sources -- Time: !time! --
+	pushd "%BOOST_LIBS_DIR%"
+	for /d %%D in (*) do (
+		if /I not "%%D"=="python" if /I not "%%D"=="numpy" if /I not "%%D"=="headers" (
+			RMDIR /s /q "%%D"
+		)
+	)
+	popd
+	echo -- Finished removing unused Boost library sources -- Time: !time! --
+) ELSE (
+	echo WARNING: Boost libs directory not found at %BOOST_LIBS_DIR%, skipping cleanup.
+)
 
 REM If building in pipeline, set the PYTHONHOME here to overwrite the existing PYTHONHOME
 REM


### PR DESCRIPTION
### Problem
Component Governance scans flag unused Boost library source directories under `libs/` as dependencies, generating false alerts. The full Boost source tree contains 100+ sub-libraries, but only `boost_python` and `boost_numpy` are actually compiled and used by the Python extension.

### Changes

`restore-packages.cmd`:
- Only performed in CI pipelines to avoid affecting local/customer environments.
- Added a post-build cleanup step that removes unused Boost library source directories from `libs/`, keeping only `python`, `numpy`, and `headers`
- Runs after `b2.exe --with-python` completes so Jamfiles are available during the build
- Includes existence check with warning fallback if the directory is not found

### How it works

After `b2` finishes building, the script iterates over all directories in `boost_1_90_0\libs\` and removes everything except:
- **`python`** — source for `boost_python` (compiled)
- **`numpy`** — source for `boost_numpy` (compiled)
- **`headers`** — Boost modular header metadata

This eliminates the source code that triggers Component Governance false positives while preserving the compiled binaries in `stage\lib\` and the headers under `boost\` that are needed at compile time and for future component governance checks.

### Testing

- The build passes.
- Compiled outputs (`libboost_python`, `libboost_numpy`) are unaffected (they live in `stage\lib\`, not `libs\`)
- Build and unit tests pass end-to-end
