### PR TITLE
Fix CodeQL SM02986: char* to wchar_t* cast warning in PythonParam

### DIFF
--- a/language-extensions/python/src/PythonParam.cpp
+++ b/language-extensions/python/src/PythonParam.cpp
@@ -345,12 +345,12 @@ void PythonStringParam<CharType>::RetrieveValueAndStrLenInd(bp::object mainNames
 					char *utf16str = PyBytes_AsString(PyUnicode_AsUTF16String(tempObj.ptr()));
 
 					// Reinterpret the bytes as wchar_t *, which we will return.
-					// The buffer contains UTF-16 code units in native byte order. The string always starts with a BOM mark.
-					// (https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF16String)
-					// We treat it as an array of 16-bit code units (CharType expected to be the size of wchar_t).
+					// The buffer contains UTF-16 code units in native byte order (https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF16String).
+					// We treat it as an array of 16-bit code units (CharType expected to be 2-bytes).
+					// Note that even for Linux, we expect 2-bytes for wchar since we compile this project with -fshort-wchar.
 					//
-					static_assert(sizeof(CharType) == sizeof(wchar_t), "CharType must match wchar_t size for UTF-16 reinterpretation.");
-					CharType *wData = reinterpret_cast<CharType *>(utf16str); // CodeQL [SM02986]: The buffer is properly aligned (divisible by 2), already contains real UTF-16 data (SQL NVARCHAR), and we know its exact length (not relying on null termination); so treating it as wchar_t* is safe.
+					static_assert(sizeof(CharType) == 2, "CharType must be 2 bytes for UTF-16 reinterpretation.");
+					CharType *wData = reinterpret_cast<CharType *>(utf16str); // CodeQL [SM02986]: The buffer contains valid UTF-16 data from PyUnicode_AsUTF16String, and the read is bounded by PyUnicode_GET_LENGTH (not null termination).
 
 					// Ignore 2 byte BOM at front of wData that was added by PyUnicode_AsUTF16String
 					//

--- a/language-extensions/python/src/PythonParam.cpp
+++ b/language-extensions/python/src/PythonParam.cpp
@@ -345,8 +345,12 @@ void PythonStringParam<CharType>::RetrieveValueAndStrLenInd(bp::object mainNames
 					char *utf16str = PyBytes_AsString(PyUnicode_AsUTF16String(tempObj.ptr()));
 
 					// Reinterpret the bytes as wchar_t *, which we will return.
+					// The buffer contains UTF-16 code units in native byte order. The string always starts with a BOM mark.
+					// (https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF16String)
+					// We treat it as an array of 16-bit code units (CharType expected to be the size of wchar_t).
 					//
-					CharType *wData = reinterpret_cast<CharType *>(utf16str);
+					static_assert(sizeof(CharType) == sizeof(wchar_t), "CharType must match wchar_t size for UTF-16 reinterpretation.");
+					CharType *wData = reinterpret_cast<CharType *>(utf16str); // CodeQL [SM02986]: The buffer is properly aligned (divisible by 2), already contains real UTF-16 data (SQL NVARCHAR), and we know its exact length (not relying on null termination); so treating it as wchar_t* is safe.
 
 					// Ignore 2 byte BOM at front of wData that was added by PyUnicode_AsUTF16String
 					//


### PR DESCRIPTION
### Summary

Addresses CodeQL alert [SM02986] (`Cast from char* to wchar_t*`) in `PythonStringParam<wchar_t>::RetrieveValueAndStrLenInd` by adding a suppression comment with justification and a **compile-time safety guard**.

### Problem

CodeQL flags the `reinterpret_cast<CharType *>(utf16str)` in `PythonParam.cpp` as potentially unsafe — casting a byte string (`char*`) to a wide-character string (`wchar_t*`) can lead to alignment issues, incorrect termination, or buffer overruns.

### Analysis

This cast is safe for the following reasons:

1. **Valid content** — `PyUnicode_AsUTF16String` produces valid UTF-16 code units in native byte order. The data is inherently `wchar_t`-compatible. ([CPython docs](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF16String))
2. **Bounded length** — The read length is determined by `PyUnicode_GET_LENGTH` (character count), not null termination, so there is no risk of buffer overrun.

### Changes

- **Alignment**: Added `static_assert(sizeof(CharType) == sizeof(wchar_t), ...)` to enforce at compile time that the template is only instantiated with a type matching `wchar_t` size.
- Added an inline CodeQL suppression comment (`// CodeQL [SM02986]: ...`) with a justification.
- Added a documentation comment block explaining why the buffer content is valid UTF-16, with a reference to the CPython docs.

### Files Changed

- `language-extensions/python/src/PythonParam.cpp`: comments + `static_assert` only; no functional change)

### Testing

- No functional code change: only comments and a compile-time assertion added.
- Consumed the artifact of this code in the engine dev branch and tests passed. There are parameter data types test coverage that cover nvarchar for Python.

### Risk
**None** — no runtime behavior change.
