### PR TITLE
Remove unused ubuntu-toolchain-r/test PPA from Linux build setup

### DIFF
--- a/language-extensions/R/README.md
+++ b/language-extensions/R/README.md
@@ -60,9 +60,8 @@ B.	Installing needed packages from respective sources.
 	#bash e.g. for Ubuntu
 	sudo apt-get -q -y install unixodbc-dev
 	sudo apt-get install build-essential software-properties-common -y
-	sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 	sudo apt-get update -y
-	apt-get install gcc-13 g++-13 -y
+	sudo apt-get install gcc-13 g++-13 -y
 	sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 70 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 	```
 

--- a/restore-packages.sh
+++ b/restore-packages.sh
@@ -6,9 +6,7 @@ apt-get -q -y install unixodbc-dev
 
 apt-get update -y
 apt-get install build-essential software-properties-common -y
-add-apt-repository ppa:ubuntu-toolchain-r/test -y 
-apt-get update -y
-apt-get install gcc-13 g++-13 -y 
+apt-get install gcc-13 g++-13 -y
 apt-get install cmake -y
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 70 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 


### PR DESCRIPTION
## Summary
Remove the `ppa:ubuntu-toolchain-r/test` PPA from `restore-packages.sh` and the matching line from the R README. This PPA is unused on Ubuntu 24.04 (the current build base) and recently became actively harmful in CI environments without egress to `ppa.launchpadcontent.net`.

## Why is this dead code?
The PPA was originally added when the build base was Ubuntu 18.04 (bionic), where it provided newer gcc versions than the base archive. PR #65 (`Update scripts for ubuntu upgrade`, `6b472b6`, 2025-10-21) bumped the base to Ubuntu 24.04 (noble) and changed the script to install `gcc-13`/`g++-13`. On noble, those packages are available **directly from the `universe` archive**:

`apt-cache policy gcc-13` on noble:
`
gcc-13:
  Installed: (none)
  Candidate: 13.3.0-6ubuntu2~24.04
  Version table:
     13.3.0-6ubuntu2~24.04 500
        500 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages
`

No apt pinning prefers the PPA, so the apt resolver picks noble's `gcc-13` regardless of whether the PPA is enabled. The `add-apt-repository` line and the follow-up `apt-get update -y` are pure overhead.

## Why does it now break builds?
On 2026-03-15 the `ubuntu-toolchain-r/test` PPA was updated to host **gcc-16** packages (`libstdc++6`, `libgcc-s1`, `libasan8`, `libgomp1`, `libitm1`, `liblsan0`, `libquadmath0`, `libtsan2`, `libubsan1`, `libcc1-0`, `libhwasan0`, `libatomic1`, `gcc-16-base`):

`
ppa.launchpadcontent.net/.../pool/main/g/gcc-16/libstdc++6_16-20260315-1ubuntu1~24~ppa1_amd64.deb
`

Because gcc-16's `libstdc++6` has a higher version number than noble's, apt's normal version resolution now upgrades the system `libstdc++6` to the PPA version on every `apt-get install` transaction (it pulls in 13 transitive runtime packages from the PPA). In CI environments without egress to `ppa.launchpadcontent.net` (for example, Microsoft's OneBranch build containers), every apt step then fails:

`
E: Failed to fetch https://ppa.launchpadcontent.net/.../gcc-16-base_*.deb
   Could not connect to ppa.launchpadcontent.net:443 (185.125.190.80). - connect (111: Connection refused)
`

I traced this against `Data-SQL-Language-Extensions` Linux pipelines — see [build 162834691](https://dev.azure.com/msazure/One/_build/results?buildId=162834691) for a representative failure. Removing the PPA at the consumer side (in `Data-SQL-Language-Extensions/build/linux/configure-apt.sh`) confirmed the diagnosis and unblocked the pipeline ([build 162911657](https://dev.azure.com/msazure/One/_build/results?buildId=162911657) is green). This upstream fix removes the workaround need.

## Change
- `restore-packages.sh`: drop `add-apt-repository ppa:ubuntu-toolchain-r/test -y` and the redundant follow-up `apt-get update -y` (the earlier `apt-get update -y` covers the install).
- `language-extensions/R/README.md`: drop the matching line from the manual install steps; add the missing `sudo` to `apt-get install gcc-13 g++-13` for consistency with surrounding lines.

## Risk
- **None on Ubuntu 24.04**: `gcc-13`/`g++-13` resolve from the noble archive. No version change.
- **Old base distros (e.g. Ubuntu 22.04 / jammy)**: `gcc-13` is also available there from the standard archive. Verified `apt-cache policy gcc-13` on jammy reports `Candidate: 13.3.0-1ubuntu1~22.04` from `jammy-updates/universe`.
- The change is two `apt-get` lines deleted; nothing else is touched.

## Validation
- Re-ran the Data-SQL-Language-Extensions Linux pipeline with this change (via a wrapper that simulates the upstream change in `configure-apt.sh`) — green end-to-end including all 1ES PT compliance gates.