### PR TITLE
C# extension: preserve exception type and InnerException in error logs

### DIFF
--- a/language-extensions/dotnet-core-CSharp/src/managed/CSharpExtension.cs
+++ b/language-extensions/dotnet-core-CSharp/src/managed/CSharpExtension.cs
@@ -940,9 +940,12 @@ namespace Microsoft.SqlServer.CSharpExtension
             }
             catch (Exception e)
             {
-                string stackTracePart = string.IsNullOrEmpty(e.StackTrace) ? string.Empty : e.StackTrace + Environment.NewLine;
-                Logging.Error(stackTracePart + "Error: " + e.Message);
-                SetLibraryError(e.Message, libraryError, libraryErrorLength);
+                Logging.Error($"InstallExternalLibrary failed: {e}");
+
+                // User-facing channel: messages only, including the inner-exception chain.
+                // Type names and stack frames are deliberately omitted - a DBA needs the cause,
+                // not the implementation.
+                SetLibraryError(FlattenMessages(e), libraryError, libraryErrorLength);
                 result = SQL_ERROR;
             }
             finally
@@ -1417,13 +1420,42 @@ namespace Microsoft.SqlServer.CSharpExtension
             }
             catch (Exception e)
             {
-                string stackTracePart = string.IsNullOrEmpty(e.StackTrace) ? string.Empty : e.StackTrace + Environment.NewLine;
-                Logging.Error(stackTracePart + "Error: " + e.Message);
-                SetLibraryError(e.Message, libraryError, libraryErrorLength);
+                // User-facing channel: messages only, including the inner-exception chain.
+                // Type names and stack frames are deliberately omitted - a DBA needs the cause,
+                // not the implementation.
+                Logging.Error($"UninstallExternalLibrary failed: {e}");
+                SetLibraryError(FlattenMessages(e), libraryError, libraryErrorLength);
                 result = SQL_ERROR;
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Flattens an exception's message chain into a single user-facing string.
+        /// Walks <c>InnerException</c> and joins each level's <c>Message</c> with
+        /// " ---> ". Returns <c>"&lt;no message&gt;"</c> if the exception and all
+        /// inner exceptions have empty messages.
+        /// </summary>
+        /// <remarks>
+        /// Message-only counterpart to <see cref="Exception.ToString"/>: same
+        /// chain-walking behavior, but no type names and no stack frames. Used to
+        /// populate <see cref="SetLibraryError"/>'s libraryError out-parameter.
+        /// The user does not need (and should not see) managed type names or stack traces.
+        /// They DO need the inner-exception message because exception wrappers have
+        /// generic outer messages and the actionable detail lives in the inner exception.
+        /// </remarks>
+        private static string FlattenMessages(Exception e)
+        {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder(e.Message ?? string.Empty);
+            for (Exception inner = e.InnerException; inner != null; inner = inner.InnerException)
+            {
+                if (!string.IsNullOrEmpty(inner.Message))
+                {
+                    sb.Append(" ---> ").Append(inner.Message);
+                }
+            }
+            return sb.Length == 0 ? "<no message>" : sb.ToString();
         }
 
         /// <summary>

--- a/language-extensions/dotnet-core-CSharp/src/managed/utils/DllUtils.cs
+++ b/language-extensions/dotnet-core-CSharp/src/managed/utils/DllUtils.cs
@@ -51,10 +51,10 @@ namespace Microsoft.SqlServer.CSharpExtension
                 }
                 catch (Exception e)
                 {
-                    // Catch unexpected exception without throwing the exception so that
-                    // all the dlls will be loaded to find matched user executor
-                    //
-                    Logging.Error(e.StackTrace + "Error: " + e.Message);
+                    // Catch unexpected exception without throwing so the loop can keep
+                    // trying remaining DLLs. Log the full exception chain (including the
+                    // inner exception) and identify which DLL failed.
+                    Logging.Error($"Failed to load or inspect '{dllPath}': {e}");
                 }
             }
 

--- a/language-extensions/dotnet-core-CSharp/src/managed/utils/ExceptionUtils.cs
+++ b/language-extensions/dotnet-core-CSharp/src/managed/utils/ExceptionUtils.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SqlServer.CSharpExtension
         /// This method calls the APIs and handles exceptions.
         /// </summary>
         /// <param name="func">
-        /// Managed language extensions APIs fucntion
+        /// Managed language extensions APIs function
         /// </param>
         /// <returns>
         /// SQL_SUCCESS(0), SQL_ERROR(-1)
@@ -37,7 +37,8 @@ namespace Microsoft.SqlServer.CSharpExtension
             }
             catch (Exception e)
             {
-                Logging.Error(e.StackTrace + "Error: " + e.Message);
+                // Log full exception chain so inner exceptions are visible.
+                Logging.Error(e.ToString());
                 return SQL_ERROR;
             }
         }

--- a/language-extensions/dotnet-core-CSharp/test/src/native/CSharpExecuteTests.cpp
+++ b/language-extensions/dotnet-core-CSharp/test/src/native/CSharpExecuteTests.cpp
@@ -528,7 +528,14 @@ namespace ExtensionApiTest
         }
         else
         {
-            EXPECT_TRUE(error.find("Error: Unable to find user class with full name:") != string::npos);
+            // On failure, surface the captured stdout/stderr so logs show the actual extension output.
+            //
+            bool matched = error.find("Unable to find user class with full name:") != string::npos;
+            EXPECT_TRUE(matched)
+                << "Expected stderr to contain 'Unable to find user class with full name:'.\n"
+                << "----- Captured stdout -----\n" << output << "\n"
+                << "----- Captured stderr -----\n" << error << "\n"
+                << "---------------------------";
         }
     }
 


### PR DESCRIPTION
## Summary

Restore PR #85's `e.ToString()` log format in `ExceptionUtils.WrapError` (which PR #92 reverted to fix a test break), propagate the same pattern to the other catch sites in the extension, and fix the test that originally motivated PR #92's revert so the better log format can stay.

## Motivation

The pre-PR-85 log format

```csharp
Logging.Error(e.StackTrace + "Error: " + e.Message);
```

drops two pieces of information that matter for production triage:

1. **The exception's type name** — `FileLoadException` vs `FileNotFoundException` vs `BadImageFormatException` vs `UnauthorizedAccessException` are all diagnosed differently, and `e.Message` alone doesn't disambiguate them.
2. **The `InnerException` chain** — BCL APIs that this extension calls heavily (`Assembly.LoadFrom`, `ZipFile.ExtractToDirectory`, `Activator.CreateInstance`, `File.Copy`) wrap the real cause inside a generic outer exception. For example, `FileLoadException`'s outer `Message` is the generic *"Could not load file or assembly '…' or one of its dependencies."*; the actionable detail (missing dependency, ACL denial, corrupt PE) lives in the inner `FileNotFoundException` or `Win32Exception`.

`e.ToString()` is strictly more informative — it preserves message + stack and adds the type and inner chain — so the right move is to relax the brittle test assertion rather than give up the better log.

Auditing the rest of the codebase turned up two other catch sites using the same `e.StackTrace + "Error: " + e.Message` pattern as the one PR #85 originally improved in `ExceptionUtils.cs`. They have the same shortcomings (no type name, no inner chain) and are updated here for the same reason: SREs and DBAs need the exception type and inner-exception chain to diagnose `Assembly.LoadFrom`, `ZipFile.ExtractToDirectory`, and `File.Copy` failures, which today's format hides.

## Changes

| File | Change |
|---|---|
| `ExceptionUtils.cs` | Re-apply `Logging.Error(e.ToString())`. Identical to the post-PR-85 state; reverts only the format-revert portion of PR #92. |
| `DllUtils.cs` (`GetUserDll` per-DLL catch) | Same `e.StackTrace + "Error: " + e.Message` pattern as the one in `ExceptionUtils.cs`. Replaced with `$"Failed to load or inspect '{dllPath}': {e}"`. Adds `dllPath` (this catch is silent — the per-DLL log was the only breadcrumb identifying which candidate failed) and the inner-exception chain for `Assembly.LoadFrom` failures. |
| `CSharpExtension.cs` (`Install`/`UninstallExternalLibrary` catches) | Same pattern again (with a `null`-guard on `e.StackTrace`). Cannot route through `ExceptionUtils.WrapError` because these APIs are contractually required to surface errors via the `libraryError` out-parameter per `sqlexternallibrary.h`. Split into log vs user-facing channel:<br>• **Log:** `Logging.Error($"...: {e}")` — full chain + stack for SREs.<br>• **User:** `SetLibraryError(FlattenMessages(e), ...)` — inner messages joined with ` ---> `, no types/stack, for T-SQL `CREATE/ALTER/DROP EXTERNAL LIBRARY` diagnostics.<br>Adds a private `FlattenMessages` helper. Previously, DBAs running `CREATE EXTERNAL LIBRARY` against a corrupt ZIP or an unreadable file saw only the generic outer message. |
| `CSharpExecuteTests.cpp` (`Execute` helper) | Drop the literal `"Error: "` prefix from the expected substring; match on `"Unable to find user class with full name:"` which is preserved by both old and new formats. Also stream captured stdout/stderr into the `EXPECT_TRUE` on failure so the next regression in this area is debuggable from the pipeline log alone (the original PR #92 incident was hard to diagnose precisely because the test only reported `Actual: false / Expected: true`). |

## Side-effect / regression analysis

- **External log scrapers:** Any consumer pattern-matching on the literal `"Error: "` prefix would stop matching. This was the risk PR #92 cited; mitigated for the in-tree test (now relaxed) and for `Install/Uninstall` by keeping the user-facing T-SQL channel formatted with `FlattenMessages` (no `e.ToString()` type prefix surfaced to T-SQL).
- **Log volume:** `e.ToString()` is multi-line where the old format was concatenated on one line. `Logging.Error` (via `InteropTextWriter`) writes the message verbatim in a single stderr write with no per-line wrapping/truncation, so multi-line is safe at the logger boundary.
- **PII / assembly identity:** `e.ToString()` is a strict superset of what was logged before. New content is exception type names and fully-qualified assembly identities — same trust boundary as existing path/stack content already in logs.
- **In-tree tests:** Only `ExecuteInvalidIntegerColumnsTest` pattern-matched on the literal `"Error: "` prefix; no other test in `language-extensions/dotnet-core-CSharp/test/` asserts on a stack-frame substring or BCL exception message produced by these catches. Verified by `grep` over the test tree.

## Related

- PR #85 (original `e.ToString()` change in `ExceptionUtils.cs`)
- PR #92 (revert of PR #85's `ExceptionUtils.cs` change due to the test break)
